### PR TITLE
disabled provider by default

### DIFF
--- a/data.example.php
+++ b/data.example.php
@@ -14,7 +14,8 @@ return [
      */
     'noMatch' => [
         'visitorInfo' => [
-            'location_provider' => 'unknown'
+            // Provider requires the "Provider" Plugin to be active. (Disabled by default in Version 2.15 and above)
+            //'location_provider' => 'unknown'
         ]
     ],
     
@@ -35,7 +36,8 @@ return [
             'location_longitude' => '9.662304',
 
             //enter your company name or do it based on your domain hierarchy
-            'location_provider' => 'myCompany'
+            // Provider requires the "Provider" Plugin to be active. (Disabled by default in Version 2.15 and above)
+            //'location_provider' => 'myCompany'
         ],
         'networks' => [
             //enter here all subnetworks for this location


### PR DESCRIPTION
As a result of Piwik-Issue 8826 (https://github.com/piwik/piwik/issues/8826) the "Provider"-Plugin is disabled in Version 2.15 and above by default. As commented in Piwik-IntranetGeoIP-Issue-21 (https://github.com/ThaDafinser/Piwik-IntranetGeoIP/issues/21#issuecomment-253749436) it would make sense, to comment out the location_provider-Field by default
